### PR TITLE
Add minimal Chrome extension

### DIFF
--- a/CHROME.md
+++ b/CHROME.md
@@ -1,0 +1,11 @@
+# Chrome Extension
+
+This repository includes a minimal Chrome extension that drafts weekly class emails using the existing JSON schedule and templates.
+
+## Load the extension
+1. Open `chrome://extensions/` in Chrome.
+2. Toggle **Developer mode** on.
+3. Click **Load unpacked** and select this repository's folder.
+4. A robot icon will appear in the toolbar. Click it to generate the next email draft in Gmail.
+
+The extension reads `classes.json`, `email_templates.json`, and `signature.txt` to assemble the message. Update those files to change recipients or template text.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This utility automates rich weekly email drafts for afterschool robotics program
 
 It also installs itself into cron for automated hourly checks and avoids re-sending duplicate emails.
 
+For a browser-based option, see [CHROME.md](CHROME.md) for a minimal Chrome extension.
+
 ---
 
 ## Setup 

--- a/background.js
+++ b/background.js
@@ -1,0 +1,35 @@
+const senderEmail = 'richard.miles@crestcomputing.com';
+const ccEmail = 'jeremy.bickel@crestcomputing.com';
+const subjectPrefix = 'Afterschool Update –';
+
+async function sendDraft() {
+  const [classes, templates, signature] = await Promise.all([
+    fetch(chrome.runtime.getURL('classes.json')).then(r => r.json()),
+    fetch(chrome.runtime.getURL('email_templates.json')).then(r => r.json()),
+    fetch(chrome.runtime.getURL('signature.txt')).then(r => r.text())
+  ]);
+  const today = new Date();
+  for (const cls of classes.classes) {
+    const startDate = new Date(cls.startDate);
+    const days = Math.floor((today - startDate) / 86400000);
+    const weeks = Math.floor(days / 7);
+    const currWeek = weeks - cls.skip.length;
+    const lessonNames = Object.keys(templates);
+    const lessonKey = lessonNames[currWeek];
+    const template = templates[lessonKey];
+    if (!template) continue;
+    const subject = template.subject || `${subjectPrefix} ${cls.className}`;
+    const footerLinks = cls.links.join('\n');
+    const body = `Howdy Parents 👋,\n\n${template.body}\n\n${footerLinks}\n\n${signature}`;
+    const params = new URLSearchParams({
+      su: subject,
+      bcc: cls.bcc.join(','),
+      cc: ccEmail,
+      body
+    });
+    chrome.tabs.create({ url: `https://mail.google.com/mail/?view=cm&fs=1&${params.toString()}` });
+    break;
+  }
+}
+
+chrome.action.onClicked.addListener(sendDraft);

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,10 @@
+{
+  "manifest_version": 3,
+  "name": "After School Email Scheduler",
+  "version": "1.0",
+  "description": "Drafts weekly class emails using the existing JSON data.",
+  "background": { "service_worker": "background.js" },
+  "action": { "default_title": "Draft class email", "default_icon": "robot.png" },
+  "icons": { "128": "robot.png" },
+  "permissions": ["tabs"]
+}


### PR DESCRIPTION
## Summary
- Add manifest and background script to draft emails as Chrome extension
- Document extension usage in new CHROME.md and update README

## Testing
- `node --check background.js`
- `jq . manifest.json`
- `php -l email-scheduler.php`


------
https://chatgpt.com/codex/tasks/task_e_689f6d3482788325a46abce36f9a90c4